### PR TITLE
Fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,14 +27,13 @@ FONT_PATH=$FONT_PATH"/wps-fonts"
 if [ -d "$FONT_PATH" ]; then
   # flush stdin
   while read -r -t 0; do read -r; done 
-  
   read -p "Font Directory already exists, continue? [y/N] " -n 1 -r 
-fi
 
-if [[ $REPLY == "" ]]; then
-  exit 0
-elif [[ $REPLY =~ ^[Nn]$ ]]; then
-  exit 0
+  if [[ $REPLY == "" ]]; then
+    exit 0
+  elif [[ $REPLY =~ ^[Nn]$ ]]; then
+    exit 0
+  fi
 fi
 
 echo -e "\nFonts will be installed in: "$FONT_PATH


### PR DESCRIPTION
I think the lines I moved were meant to be in the if-block that checks if the font folder already exists (otherwise the script just exits without notification and without installing anything).